### PR TITLE
Add SEO component and sitemap/robots

### DIFF
--- a/components/SEO.js
+++ b/components/SEO.js
@@ -1,0 +1,40 @@
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+import { SITE_URL, SITE_NAME, DEFAULT_DESCRIPTION, DEFAULT_OG_IMAGE } from '../lib/constants';
+
+export default function SEO({
+  title,
+  description = DEFAULT_DESCRIPTION,
+  ogImage = DEFAULT_OG_IMAGE,
+  ogType = 'website',
+  noindex = false,
+}) {
+  const router = useRouter();
+  const canonicalUrl = `${SITE_URL}${router.asPath.split('?')[0]}`;
+  const fullTitle = title ? `${title} — ${SITE_NAME}` : SITE_NAME;
+
+  return (
+    <Head>
+      <title>{fullTitle}</title>
+      <meta name="description" content={description} />
+      <link rel="canonical" href={canonicalUrl} />
+
+      {noindex && <meta name="robots" content="noindex, nofollow" />}
+
+      {/* Open Graph */}
+      <meta property="og:type" content={ogType} />
+      <meta property="og:url" content={canonicalUrl} />
+      <meta property="og:title" content={fullTitle} />
+      <meta property="og:description" content={description} />
+      <meta property="og:image" content={ogImage} />
+      <meta property="og:site_name" content={SITE_NAME} />
+
+      {/* Twitter */}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:url" content={canonicalUrl} />
+      <meta name="twitter:title" content={fullTitle} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={ogImage} />
+    </Head>
+  );
+}

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,5 @@
+export const SITE_URL = 'https://elliotkoh.dev';
+export const SITE_NAME = 'Elliot Koh';
+export const DEFAULT_DESCRIPTION =
+  'Developer and designer passionate about building meaningful tools, clean interfaces, and systems that elevate how we live and work.';
+export const DEFAULT_OG_IMAGE = `${SITE_URL}/images/hero/banner.webp`;

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,0 +1,27 @@
+/** @type {import('next-sitemap').IConfig} */
+module.exports = {
+  siteUrl: 'https://elliotkoh.dev',
+  generateRobotsTxt: false, // We maintain robots.txt manually
+  changefreq: 'monthly',
+  priority: 0.7,
+  sitemapSize: 5000,
+  exclude: ['/api/*'],
+  transform: async (config, path) => {
+    // Give the homepage highest priority
+    if (path === '/') {
+      return {
+        loc: path,
+        changefreq: 'weekly',
+        priority: 1.0,
+        lastmod: new Date().toISOString(),
+      };
+    }
+
+    return {
+      loc: path,
+      changefreq: config.changefreq,
+      priority: config.priority,
+      lastmod: new Date().toISOString(),
+    };
+  },
+};

--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,37 @@ const nextConfig = {
     // Serve optimized formats
     formats: ['image/avif', 'image/webp'],
   },
+
+  // Security & best-practice headers
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+          {
+            key: 'X-XSS-Protection',
+            value: '1; mode=block',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=()',
+          },
+        ],
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "autoprefixer": "^10.4.21",
         "cypress": "^14.5.4",
         "next": "^15.4.6",
+        "next-sitemap": "^4.2.3",
         "postcss": "^8.5.6",
         "react": "^19.1.1",
         "react-burger-menu": "^3.1.0",
@@ -49,6 +50,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@corex/deepmerge": {
+      "version": "4.0.43",
+      "resolved": "https://registry.npmjs.org/@corex/deepmerge/-/deepmerge-4.0.43.tgz",
+      "integrity": "sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ==",
+      "license": "MIT"
     },
     "node_modules/@cypress/request": {
       "version": "3.0.10",
@@ -719,6 +726,41 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1268,6 +1310,18 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/browser-resolve": {
       "version": "1.11.3",
@@ -2008,6 +2062,31 @@
       ],
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -2028,6 +2107,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/forever-agent": {
@@ -2156,6 +2247,18 @@
       "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/global-dirs": {
@@ -2325,12 +2428,33 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-installed-globally": {
@@ -2346,6 +2470,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-path-inside": {
@@ -2834,6 +2967,28 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -2968,6 +3123,39 @@
           "optional": true
         }
       }
+    },
+    "node_modules/next-sitemap": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/next-sitemap/-/next-sitemap-4.2.3.tgz",
+      "integrity": "sha512-vjdCxeDuWDzldhCnyFCQipw5bfpl4HmZA7uoo3GAaYGjGgfL4Cxb1CiztPuWGmS+auYs7/8OekRS8C2cjdAsjQ==",
+      "funding": [
+        {
+          "url": "https://github.com/iamvishnusankar/next-sitemap.git"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@corex/deepmerge": "^4.0.43",
+        "@next/env": "^13.4.3",
+        "fast-glob": "^3.2.12",
+        "minimist": "^1.2.8"
+      },
+      "bin": {
+        "next-sitemap": "bin/next-sitemap.mjs",
+        "next-sitemap-cjs": "bin/next-sitemap.cjs"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "next": "*"
+      }
+    },
+    "node_modules/next-sitemap/node_modules/@next/env": {
+      "version": "13.5.11",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.11.tgz",
+      "integrity": "sha512-fbb2C7HChgM7CemdCY+y3N1n8pcTKdqtQLbC7/EQtPdLvlMUT9JX/dBYl8MMZAtYG4uVMyPFHXckb68q/NRwqg==",
+      "license": "MIT"
     },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
@@ -3107,6 +3295,18 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -3206,6 +3406,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
@@ -3280,10 +3500,43 @@
         "node": ">=8"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rfdc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
       "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "node_modules/rxjs": {
       "version": "7.8.1",
@@ -3701,6 +3954,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "postbuild": "next-sitemap",
     "export": "next export"
   },
   "dependencies": {
@@ -12,6 +13,7 @@
     "autoprefixer": "^10.4.21",
     "cypress": "^14.5.4",
     "next": "^15.4.6",
+    "next-sitemap": "^4.2.3",
     "postcss": "^8.5.6",
     "react": "^19.1.1",
     "react-burger-menu": "^3.1.0",

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -4,7 +4,7 @@ import Document, { Html, Head, Main, NextScript } from 'next/document';
 class MyDocument extends Document {
   render() {
     return (
-      <Html>
+      <Html lang="en">
         <Head>
           <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@400;500;600;700;800;900&display=swap" rel="stylesheet" />
 

--- a/pages/ai03-vega.js
+++ b/pages/ai03-vega.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import Image from 'next/image';
-import Head from 'next/head';
 import ImageLightbox from '../components/ImageLightbox';
+import SEO from '../components/SEO';
 
 const VegaPage = () => {
     // Small display image (fast loading)
@@ -14,9 +14,11 @@ const VegaPage = () => {
 
     return (
         <div className="mt-[5rem] xl:mt-[10rem] mx-auto p-6 sm:px-6 lg:px-8 bg-white rounded-t-3xl relative">
-            <Head>
-                <title>ai03 Vega — Elliot Koh</title>
-            </Head>
+            <SEO
+                title="ai03 Vega"
+                description="Rose gold ai03 Vega with GMK Peaches n Cream R1 — featuring Holy Boba switches on a POM plate with hotswap PCB."
+                ogImage="https://elliotkoh.dev/images/keyboards/ai03-vega-small.webp"
+            />
 
             <div className="mt-[1%] mx-auto pb-[5%]">
                 {/* Main Image */}

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import Head from 'next/head';
+import SEO from '../components/SEO';
 
 export default function Contact() {
   const [formData, setFormData] = useState({
@@ -45,9 +45,10 @@ export default function Contact() {
 
   return (
     <div className="font-semibold">
-      <Head>
-        <title>Get in touch — Elliot Koh</title>
-      </Head>
+      <SEO
+        title="Get in Touch"
+        description="Have a project idea or just want to say hello? Get in touch with Elliot Koh — I'd love to hear from you."
+      />
 
       <div className="max-w-4xl mx-auto pt-[5rem] xl:pt-[10rem] px-4 sm:px-6 lg:px-8">
         <div className="bg-white rounded-2xl p-8 shadow-xl ring-1 ring-gray-100 mb-5">

--- a/pages/hobbies.js
+++ b/pages/hobbies.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Image from 'next/image';
-import Head from 'next/head';
 import Link from 'next/link';
+import SEO from '../components/SEO';
 
 const Hobby = ({ title, description, imageSrc, imageAlt, category, customTitle }) => (
   customTitle ? (
@@ -34,9 +34,10 @@ const Hobby = ({ title, description, imageSrc, imageAlt, category, customTitle }
 export default function Hobbies() {
   return (
     <div className="mt-[5rem] xl:mt-[10rem] mx-auto p-6 sm:px-6 lg:px-8 bg-white rounded-t-3xl flex flex-col items-center pb-10">
-      <Head>
-        <title>Hobbies — Elliot Koh</title>
-      </Head>
+      <SEO
+        title="Hobbies"
+        description="Mechanical keyboards, collectibles, desk setups, coding projects, and more — a look at what I enjoy outside of work."
+      />
       <div className="max-w-6xl">
         <h1 className="text-3xl font-bold text-left my-5">Hobbies</h1>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8 lowercase text-white">

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,6 +5,8 @@ import Link from 'next/link';
 import WorkCard from '../components/WorkCard';
 import WorksSection from '../components/WorksSection';
 import { works } from '../data/works';
+import SEO from '../components/SEO';
+import { SITE_URL } from '../lib/constants';
 
 const HomePage = () => {
   // Create a ref for the "About Us" section
@@ -16,24 +18,35 @@ const HomePage = () => {
 
   return (
     <>
+      <SEO
+        title="Home"
+        description="Developer and designer passionate about building meaningful tools, clean interfaces, and systems that elevate how we live and work."
+      />
       <Head>
-        <title>Home — Elliot Koh</title>
-        <meta name="description" content="A skilled Computer Science undergrad specialising in crafting captivating digital experiences, merging technology and creativity to elevate startups in the digital realm." />
-        <meta name="theme-color" content="#e8ecef" />
-
-        {/* Open Graph / Facebook */}
-        <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://elliotkoh.netlify.app/" />
-        <meta property="og:title" content="Home — Elliot Koh" />
-        <meta property="og:description" content="A skilled Computer Science undergrad specialising in crafting captivating digital experiences, merging technology and creativity to elevate startups in the digital realm." />
-        <meta property="og:image" content="https://elliotkoh.netlify.app/images/hero/banner.webp" />
-
-        {/* Twitter */}
-        <meta property="twitter:card" content="summary_large_image" />
-        <meta property="twitter:url" content="https://elliotkoh.netlify.app/" />
-        <meta property="twitter:title" content="Home — Elliot Koh" />
-        <meta property="twitter:description" content="A skilled Computer Science undergrad specialising in crafting captivating digital experiences, merging technology and creativity to elevate startups in the digital realm." />
-        <meta property="twitter:image" content="https://elliotkoh.netlify.app/images/hero/banner.webp" />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'Person',
+              name: 'Elliot Koh',
+              url: SITE_URL,
+              image: `${SITE_URL}/images/hero/testimg.webp`,
+              jobTitle: 'Developer & Designer',
+              description:
+                'Developer and designer passionate about building meaningful tools, clean interfaces, and systems that elevate how we live and work.',
+              sameAs: [
+                'https://hypertools.dev',
+              ],
+              knowsAbout: [
+                'Web Development',
+                'UI/UX Design',
+                'Software Engineering',
+                'Computer Science',
+              ],
+            }),
+          }}
+        />
       </Head>
 
       <div style={{ height: 'calc(100vh - 100px)' }} className="flex flex-col items-center justify-center relative select-none text-black overflow-hidden">

--- a/pages/keyboards.js
+++ b/pages/keyboards.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import Image from 'next/image'; // Importing Image from next/image
-import Head from 'next/head';
+import Image from 'next/image';
 import Link from 'next/link';
+import SEO from '../components/SEO';
 
 const Keyboard = ({ title, description, imageSrc, imageAlt, category, customTitle }) => {
 
@@ -45,9 +45,10 @@ const Keyboard = ({ title, description, imageSrc, imageAlt, category, customTitl
 export default function Keyboards() {
   return (
     <div className="pb-[10%] mt-[5rem] xl:mt-[10rem] mx-auto p-6 sm:px-6 lg:px-8 bg-white rounded-t-3xl flex flex-col items-center">
-      <Head>
-        <title>Keyboards — Elliot Koh</title>
-      </Head>
+      <SEO
+        title="Keyboards"
+        description="A collection of custom mechanical keyboards — from endgame builds to unique switches and keycap sets."
+      />
       <div className="max-w-8xl">
         <h1 className="text-3xl font-bold text-left my-5">Keyboards</h1>
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8 lowercase text-white">

--- a/pages/keycult-2-65.js
+++ b/pages/keycult-2-65.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import Image from 'next/image';
-import Head from 'next/head';
 import ImageLightbox from '../components/ImageLightbox';
+import SEO from '../components/SEO';
 
 const KeycultPage = () => {
     // Small display images (fast loading)
@@ -100,9 +100,11 @@ const KeycultPage = () => {
 
     return (
         <div className="mt-[5rem] xl:mt-[10rem] mx-auto p-6 sm:px-6 lg:px-8 bg-white rounded-t-3xl relative">
-            <Head>
-                <title>Keycult 2-65</title>
-            </Head>
+            <SEO
+                title="Keycult 2/65"
+                description="Ocean grey Keycult 2/65 with GMK Shoko R2 — featuring lubed MX Blacks on an aluminum plate with WT65-A PCB."
+                ogImage="https://elliotkoh.dev/images/keyboards/keycult1-small.webp"
+            />
 
             {/* Image Carousel */}
             <div className="mt-[1%] mx-auto pb-[5%]">

--- a/pages/owlab-spring.js
+++ b/pages/owlab-spring.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import Image from 'next/image';
-import Head from 'next/head';
 import ImageLightbox from '../components/ImageLightbox';
+import SEO from '../components/SEO';
 
 const SpringPage = () => {
     // Small display image (fast loading)
@@ -14,9 +14,11 @@ const SpringPage = () => {
 
     return (
         <div className="mt-[5rem] xl:mt-[10rem] mx-auto p-6 sm:px-6 lg:px-8 bg-white rounded-t-3xl relative">
-            <Head>
-                <title>Owlab Spring — Elliot Koh</title>
-            </Head>
+            <SEO
+                title="Owlab Spring"
+                description="Lilac Owlab Spring with GMK Frost Witch R1 — featuring Creamsicle Frankenswitch on a hotswap PCB."
+                ogImage="https://elliotkoh.dev/images/keyboards/spring-small.webp"
+            />
 
             <div className="mt-[1%] mx-auto pb-[5%]">
                 {/* Main Image */}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://elliotkoh.dev/sitemap.xml


### PR DESCRIPTION
Introduce a reusable SEO component and site constants, replace per-page <Head> metadata with the SEO component across pages, and add structured data on the homepage. Add next-sitemap configuration and a postbuild script to generate sitemaps, include a manual public/robots.txt, and update package.json/package-lock with next-sitemap. Also add security-related headers in next.config.js and set the HTML lang attribute in _document.js.