### PR TITLE
Add back link and adjust Next/Image props

### DIFF
--- a/pages/ai03-vega.js
+++ b/pages/ai03-vega.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import ImageLightbox from '../components/ImageLightbox';
 import SEO from '../components/SEO';
 
@@ -19,6 +20,13 @@ const VegaPage = () => {
                 description="Rose gold ai03 Vega with GMK Peaches n Cream R1 — featuring Holy Boba switches on a POM plate with hotswap PCB."
                 ogImage="https://elliotkoh.dev/images/keyboards/ai03-vega-small.webp"
             />
+
+            <Link href="/keyboards" className="inline-flex items-center gap-1 text-sm font-semibold text-gray-500 hover:text-gray-900 transition-colors duration-200 mb-4">
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                </svg>
+                Back to Keyboards
+            </Link>
 
             <div className="mt-[1%] mx-auto pb-[5%]">
                 {/* Main Image */}

--- a/pages/keyboards/[slug].js
+++ b/pages/keyboards/[slug].js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import ImageLightbox from '../../components/ImageLightbox';
 import SEO from '../../components/SEO';
 import { keyboardPosts, getKeyboardBySlug, getKeyboardImages } from '../../data/keyboards';
@@ -84,6 +85,13 @@ export default function KeyboardPage({ keyboard, images }) {
         ogImage={`${SITE_URL}${display[0]}`}
       />
 
+      <Link href="/keyboards" className="inline-flex items-center gap-1 text-sm font-semibold text-gray-500 hover:text-gray-900 transition-colors duration-200 mb-4">
+        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+        </svg>
+        Back to Keyboards
+      </Link>
+
       <div className="mt-[1%] mx-auto pb-[5%]">
         {/* Main Image */}
         <div className="max-w-[81rem] mx-auto">
@@ -98,8 +106,8 @@ export default function KeyboardPage({ keyboard, images }) {
                 width={1600}
                 height={1000}
                 className="object-cover rounded-xl"
-                priority={currentIndex === 0}
-                sizes="(max-width: 1296px) 100vw, 1296px"
+                priority
+                unoptimized
               />
             </div>
             {/* Arrows — only show if more than 1 image */}
@@ -134,6 +142,7 @@ export default function KeyboardPage({ keyboard, images }) {
                     alt={`Thumbnail ${index + 1}`}
                     width={64}
                     height={64}
+                    unoptimized
                     className={`object-cover rounded-lg transition-opacity ${
                       index === currentIndex ? 'opacity-100' : 'opacity-50'
                     }`}

--- a/pages/keycult-2-65.js
+++ b/pages/keycult-2-65.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import ImageLightbox from '../components/ImageLightbox';
 import SEO from '../components/SEO';
 
@@ -103,6 +104,13 @@ const KeycultPage = () => {
                 ogImage="https://elliotkoh.dev/images/keyboards/keycult1-small.webp"
             />
 
+            <Link href="/keyboards" className="inline-flex items-center gap-1 text-sm font-semibold text-gray-500 hover:text-gray-900 transition-colors duration-200 mb-4">
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                </svg>
+                Back to Keyboards
+            </Link>
+
             {/* Image Carousel */}
             <div className="mt-[1%] mx-auto pb-[5%]">
                 {/* Main Image */}
@@ -118,8 +126,8 @@ const KeycultPage = () => {
                                 width={1600}
                                 height={1000}
                                 className="object-cover rounded-xl"
-                                priority={currentIndex === 0}
-                                sizes="(max-width: 1296px) 100vw, 1296px"
+                                priority
+                                unoptimized
                             />
                         </div>
                         {/* Left Arrow */}
@@ -150,6 +158,7 @@ const KeycultPage = () => {
                                     alt={`Thumbnail ${index + 1}`}
                                     width={64}
                                     height={64}
+                                    unoptimized
                                     className={`object-cover rounded-lg transition-opacity ${
                                         index === currentIndex ? 'opacity-100' : 'opacity-50'
                                     }`}

--- a/pages/owlab-spring.js
+++ b/pages/owlab-spring.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import ImageLightbox from '../components/ImageLightbox';
 import SEO from '../components/SEO';
 
@@ -19,6 +20,13 @@ const SpringPage = () => {
                 description="Lilac Owlab Spring with GMK Frost Witch R1 — featuring Creamsicle Frankenswitch on a hotswap PCB."
                 ogImage="https://elliotkoh.dev/images/keyboards/spring-small.webp"
             />
+
+            <Link href="/keyboards" className="inline-flex items-center gap-1 text-sm font-semibold text-gray-500 hover:text-gray-900 transition-colors duration-200 mb-4">
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                </svg>
+                Back to Keyboards
+            </Link>
 
             <div className="mt-[1%] mx-auto pb-[5%]">
                 {/* Main Image */}


### PR DESCRIPTION
Import Next.js Link and add a "Back to Keyboards" inline link (with arrow SVG) to several keyboard pages (ai03-vega.js, keycult-2-65.js, owlab-spring.js, and pages/keyboards/[slug].js) to improve navigation. Also updated Image usage on the dynamic keyboard page and two static pages: set the main image to always use priority and unoptimized, removed the conditional priority/sizes, and mark thumbnail images unoptimized to bypass Next.js image optimization for these assets.