### PR TITLE
Only reset on horizontal window resize

### DIFF
--- a/components/FallingLetters.js
+++ b/components/FallingLetters.js
@@ -179,10 +179,15 @@ const FallingLetters = ({ text, onScrollToAbout }) => {
     };
   }, [resetPhysics]);
 
-  // On resize: reset everything so letters return to readable positions
+  // On horizontal resize only: reset letters (ignore vertical — Safari mobile toolbar)
+  const lastWidthRef = useRef(typeof window !== 'undefined' ? window.innerWidth : 0);
   useEffect(() => {
     let resizeTimer;
     const handleResize = () => {
+      const newWidth = window.innerWidth;
+      if (newWidth === lastWidthRef.current) return; // vertical-only change, ignore
+      lastWidthRef.current = newWidth;
+
       clearTimeout(resizeTimer);
       resizeTimer = setTimeout(() => {
         if (hasTriggeredRef.current) {


### PR DESCRIPTION
Avoid triggering a full reset on vertical-only resizes (e.g. mobile Safari toolbar). Add lastWidthRef (initialized safely for SSR) and in the resize handler compare window.innerWidth to the last value; if unchanged, bail out. Update lastWidthRef when width changes and preserve the existing debounce/reset logic.